### PR TITLE
Replace webauthn.io with SimpleWebAuthn library

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,17 +100,6 @@
                             </a>
                         </div>
                         <div class="mt-3 col-sm-12 col-md-6 col-lg-4 d-flex flex-column">
-                            <a class="library" href="https://github.com/duo-labs/webauthn.io">
-                                <h5>Go</h5>
-                                <p class="mb-1"><img class="icon" src="/dist/images/github.svg"> <span
-                                        class="ml-2">duo-labs/webauthn.io</span></p>
-                                <p class="mb-1"><img class="icon" src="/dist/images/author.svg"> <span class="ml-2">Duo
-                                        Labs</span></p>
-                                <p class="mb-1"><img class="icon" src="/dist/images/brackets.svg"> <span
-                                        class="ml-2">Demo</span></p>
-                            </a>
-                        </div>
-                        <div class="mt-3 col-sm-12 col-md-6 col-lg-4 d-flex flex-column">
                             <a class="library" href="https://github.com/koesie10/webauthn">
                                 <h5>Go</h5>
                                 <p class="mb-1"><img class="icon" src="/dist/images/github.svg"> <span
@@ -119,6 +108,22 @@
                                         Vlaswinkel</span></p>
                                 <p class="mb-1"><img class="icon" src="/dist/images/brackets.svg"> <span
                                         class="ml-2">Server</span></p>
+                            </a>
+                        </div>
+                        <div class="mt-3 col-sm-12 col-md-6 col-lg-4 d-flex flex-column">
+                            <a class="library" href="https://github.com/MasterKale/SimpleWebAuthn" target="_blank" rel="noopener noreferrer">
+                                <h5>TypeScript</h5>
+                                <p class="mb-1"><img class="icon" src="/dist/images/github.svg">
+                                    <span class="ml-2">SimpleWebAuthn</span>
+                                </p>
+                                <p class="mb-1">
+                                    <img class="icon" src="/dist/images/author.svg">
+                                    <span class="ml-2">Matthew Miller</span>
+                                </p>
+                                <p class="mb-1">
+                                    <img class="icon" src="/dist/images/brackets.svg">
+                                    <span class="ml-2">Server</span>
+                                </p>
                             </a>
                         </div>
                         <div class="mt-3 col-sm-12 col-md-6 col-lg-4 d-flex flex-column">


### PR DESCRIPTION
This PR plants my SimpleWebAuthn stake in the ground before this project takes off and I face stiffer competition!

I replaced the **duo-labs/webauthn.io** project since it's a demo, and the site is likely to pick up demo capabilities of its own that will probably make this tile redundant. If we want I can make this PR additive so everything remains and we simply start stacking additional libs ✌️ 

<img width="954" alt="Screen Shot 2020-11-16 at 9 56 24 AM" src="https://user-images.githubusercontent.com/5166470/99289585-04247880-27f2-11eb-94b8-29d1bf50f302.png">