### PR TITLE
fix/simplewebauthn-add-browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
                                 </p>
                                 <p class="mb-1">
                                     <img class="icon" src="/dist/images/brackets.svg">
-                                    <span class="ml-2">Server</span>
+                                    <span class="ml-2">Server, Browser</span>
                                 </p>
                             </a>
                         </div>


### PR DESCRIPTION
I forgot to include a mention of SimpleWebAuthn’s support for browsers too.

I was going to use "client" instead of "browser" but the latter I think makes things less ambiguous. This'll be a useful distinction going forward if we also want to feature front-end-only libraries like Github's https://github.com/github/webauthn-json.